### PR TITLE
fixed go.mod module lib -> github.com/getbrevo/brevo-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module lib
+module github.com/getbrevo/brevo-go
 
 go 1.22.3
 


### PR DESCRIPTION
error:
go: github.com/getbrevo/brevo-go@v1.1.0: parsing go.mod:
        module declares its path as: lib
                but was required as: github.com/getbrevo/brevo-go